### PR TITLE
Parse dates in local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ddmmyyyy
 
-Parses UTC dates in dd/mm/yyyy or mm/dd/yyyy format and rejects invalid strings.
+Parses local dates in dd/mm/yyyy or mm/dd/yyyy format and rejects invalid strings.
 
 # example
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ Parser.prototype.parse = function(dateString) {
     var dd = m[this.layout.indexOf('d') + 1];
     var mm = m[this.layout.indexOf('m') + 1];
     var yy = m[this.layout.indexOf('y') + 1];
-    var date = new Date([yy, mm, dd].join('-'));
+    var date = new Date(Number(yy), Number(mm) - 1, Number(dd));
     if (date.getFullYear() == yy && (date.getMonth() + 1) == mm && date.getDate() == dd) {
       return date;
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parses UTC dates in dd/mm/yyyy or mm/dd/yyyy formats",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "TZ=UTC mocha && TZ=Etc/GMT-12 mocha && TZ=Etc/GMT+12 mocha"
   },
   "author": "Josh Chisholm <joshuachisholm@gmail.com>",
   "license": "MIT",

--- a/test/test.js
+++ b/test/test.js
@@ -11,15 +11,15 @@ describe('ddmmyyyy', function() {
     });
 
     it('creates a Date from 13/12/2001', function() {
-      expect(parser.parse('13/12/2001')).to.eql(new Date('2001-12-13'));
+      expect(parser.parse('13/12/2001')).to.eql(new Date(2001, 11, 13));
     });
 
     it('creates a Date from 31/1/2001', function() {
-      expect(parser.parse('31/1/2001')).to.eql(new Date('2001-01-31'));
+      expect(parser.parse('31/1/2001')).to.eql(new Date(2001, 0, 31));
     });
 
     it('creates a Date from 29/02/2016, because 2016 is a leap year', function() {
-      expect(parser.parse('29/02/2016')).to.eql(new Date('2016-02-29'));
+      expect(parser.parse('29/02/2016')).to.eql(new Date(2016, 1, 29));
     });
 
     it('rejects 29/02/2017, because 2017 is not a leap year', function() {
@@ -33,15 +33,15 @@ describe('ddmmyyyy', function() {
     });
 
     it('creates a Date from 12/13/2001', function() {
-      expect(parser.parse('12/13/2001')).to.eql(new Date('2001-12-13'));
+      expect(parser.parse('12/13/2001')).to.eql(new Date(2001, 11, 13));
     });
 
     it('creates a Date from 1/31/2001', function() {
-      expect(parser.parse('1/31/2001')).to.eql(new Date('2001-01-31'));
+      expect(parser.parse('1/31/2001')).to.eql(new Date(2001, 0, 31));
     });
 
     it('creates a Date from 02/29/2016, because 2016 is a leap year', function() {
-      expect(parser.parse('02/29/2016')).to.eql(new Date('2016-02-29'));
+      expect(parser.parse('02/29/2016')).to.eql(new Date(2016, 1, 29));
     });
 
     it('rejects 02/29/2017, because 2017 is not a leap year', function() {


### PR DESCRIPTION
Not sure if this is right... but...

When I type `8/16/2016` into a browser running in San Francisco (currently UTC-7) then I should get a date that looks like `2016-08-16T07:00:00.000Z`, which is the midnight at the beginning of the 4th of October, 2016, in San Fran - or 7 AM GMT time.

So.. assuming this library is for users entering dates in their local time, this is a patch to make that work.

Otherwise, we should be using date.getUTCDate(), etc, to compare dates.
